### PR TITLE
changes post requests to get requests

### DIFF
--- a/app/assets/javascripts/index.js
+++ b/app/assets/javascripts/index.js
@@ -136,10 +136,9 @@ window.addEventListener('load', () => {
 		const lng = e.latlng.lng;
 		const settings = {
 			url: '/ebird',
-			method: 'POST',
+			method: 'GET',
 			timeout: 0,
 			data: {
-				authenticity_token: '<%= form_authenticity_token %>',
 				lat,
 				lng,
 				num_req: 100,
@@ -206,10 +205,9 @@ window.addEventListener('load', () => {
 	function hitEbirdEndpoint(pos) {
 		const settings = {
 			url: '/ebird',
-			method: 'POST',
+			method: 'GET',
 			timeout: 0,
 			data: {
-				authenticity_token: '<%= form_authenticity_token %>',
 				lat: pos.coords.latitude,
 				lng: pos.coords.longitude,
 				num_req: 100,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,4 +3,5 @@ Rails.application.routes.draw do
   root 'application#index'
   get '/locations', to: 'application#show'
   post '/ebird', to: 'ebird#data'
+  get '/ebird', to: 'ebird#data'
 end

--- a/spec/requests/ebird_request_spec.rb
+++ b/spec/requests/ebird_request_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "Ebirds", type: :request do
     VCR.use_cassette('ebird/get_image_from_name') do
       VCR.use_cassette('ebird/get_bird_from_cords') do
 
-        post "/ebird", :params => { :lat => 37.42, :lng => -121.91, :rare => false, :num_req => 1, :num_ret => 1}
+        get "/ebird", :params => { :lat => 37.42, :lng => -121.91, :rare => false, :num_req => 1, :num_ret => 1}
         expect(response.content_type).to eq("application/json; charset=utf-8")
         expect(response.parsed_body()["imgsrc"].first).to eq("https://upload.wikimedia.org/wikipedia/commons/4/40/Canada_goose_on_Seedskadee_NWR_%2827826185489%29.jpg")
 


### PR DESCRIPTION
The application was sending POST requests through the eBird API when GET requests were more appropriate. We were struggling to get the form_authenticity_token to be sent properly after the javascript and html files were separated a while back, but they aren't necessary when using GET requests anyways, so this resolved the issue. Deleted the form_authenticity_token parameters from the javascript page that was trying to use it.